### PR TITLE
Rename the new helpers to encode/decode feature properties 

### DIFF
--- a/Sources/GeoJSONKit/GeoJSON+Codable.swift
+++ b/Sources/GeoJSONKit/GeoJSON+Codable.swift
@@ -108,27 +108,26 @@ extension GeoJSON.GeometryObject: Codable {
 
 extension GeoJSON.Feature {
   
-  /// Create a feature with the provided `Encodable` as the properties
+  /// Create a feature with the provided `Encodable` model as the properties
   /// - Parameters:
   ///   - geometry: Geometry
   ///   - properties: Known structure to use for the properties
   ///   - id: GeoJSON-compatible ID, i.e., an Integer or a String
   ///   - configure: Optional handler to configure how to encode the `Encodable`
-  public init<P: Encodable>(geometry: GeoJSON.GeometryObject, properties: P, id: AnyHashable? = nil, configure: (inout JSONEncoder) -> Void  = { _ in }) throws {
+  public init<P: Encodable>(geometry: GeoJSON.GeometryObject, model: P, id: AnyHashable? = nil, configure: (inout JSONEncoder) -> Void  = { _ in }) throws {
     var encoder = JSONEncoder()
     configure(&encoder)
-    let data = try encoder.encode(properties)
+    let data = try encoder.encode(model)
     let asDict = try JSONSerialization.jsonObject(with: data) as? [String: AnyHashable]
     self.init(geometry: geometry, properties: asDict, id: id)
   }
   
-  
-  /// Parses the properties as the provided `Decodable`
+  /// Parses the properties as the provided `Decodable` model
   /// - Parameters:
   ///   - type: Known structure to decode the feature's properties again
   ///   - configure: Optional handler to configure how to decode the `Decodable`
   /// - Returns: Properties decoded as the provided `Decodable`
-  public func properties<P: Decodable>(as type: P.Type, configure: (inout JSONDecoder) -> Void  = { _ in }) throws -> P {
+  public func model<P: Decodable>(as type: P.Type, configure: (inout JSONDecoder) -> Void  = { _ in }) throws -> P {
     let asData = try JSONSerialization.data(withJSONObject: properties ?? [:])
     var decoder = JSONDecoder()
     configure(&decoder)

--- a/Tests/GeoJSONKitTests/GeoJSONCodableTest.swift
+++ b/Tests/GeoJSONKitTests/GeoJSONCodableTest.swift
@@ -194,5 +194,27 @@ final class GeoJSONCodableTest: XCTestCase {
     let data = try XCTestCase.loadData(filename: "featurecollection")
     XCTAssertThrowsError(try JSONDecoder().decode(GeoJSON.GeometryObject.self, from: data))
   }
+  
+  func testNonTypedInitializerDoesNotThrow() throws {
+    let point = GeoJSON.GeometryObject.single(.point(.init(latitude: -33.9451, longitude: 151.2581)))
+    let feature = GeoJSON.Feature(geometry: point, properties: ["key": "value"])
+    XCTAssertNotNil(feature)
+  }
+
+  func testTypedInitializerCanThrow() throws {
+    let point = GeoJSON.GeometryObject.single(.point(.init(latitude: -33.9451, longitude: 151.2581)))
+    let model = Model(name: "Test", number: 3517, date: Date())
+    let feature = try GeoJSON.Feature(geometry: point, model: model)
+    XCTAssertNotNil(feature)
     
+    let restored = try feature.model(as: Model.self)
+    XCTAssertEqual(model, restored)
+  }
+
+}
+
+fileprivate struct Model: Codable, Equatable {
+  let name: String
+  let number: Int
+  let date: Date
 }

--- a/Tests/GeoJSONKitTests/SerializationTest.swift
+++ b/Tests/GeoJSONKitTests/SerializationTest.swift
@@ -32,7 +32,5 @@ class SerializationTest: XCTestCase {
       let fromDict = try GeoJSON.GeometryObject(dict: asDict)
       XCTAssertEqual(geometry, fromDict)
     }
-    
   }
-  
 }


### PR DESCRIPTION
Now uses "model" rather than "properties" to avoid name clashes due to function overload.

Also add tests for it.